### PR TITLE
Fix bug

### DIFF
--- a/cafe.rb
+++ b/cafe.rb
@@ -2,17 +2,17 @@
 require 'debug'
 
 DRINKS = [
-  { name: 'コーヒー', price: '300' },
-  { name: 'カフェラテ', price: '400' },
-  { name: 'チャイ', price: '460' },
-  { name: 'エスプレッソ', price: '340' },
-  { name: '緑茶', price: '450' }
+  { name: 'コーヒー', price: 300 },
+  { name: 'カフェラテ', price: 400 },
+  { name: 'チャイ', price: 460 },
+  { name: 'エスプレッソ', price: 340 },
+  { name: '緑茶', price: 450 }
 ].freeze
 
 FOODS = [
-  { name: 'チーズケーキ', price: '470' },
-  { name: 'アップルパイ', price: '520' },
-  { name: 'ホットサンド', price: '410' }
+  { name: 'チーズケーキ', price: 470 },
+  { name: 'アップルパイ', price: 520 },
+  { name: 'ホットサンド', price: 410 }
 ].freeze
 
 def take_order(menus)

--- a/cafe.rb
+++ b/cafe.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'debug'
 
 DRINKS = [
   { name: 'コーヒー', price: '300' },
@@ -20,7 +21,7 @@ def take_order(menus)
   end
   print '>'
   order_number = gets.to_i
-  puts "#{menus[order_number][:name]}(#{menus[order_number][:price]}円)ですね。"
+  puts "#{menus[order_number - 1][:name]}(#{menus[order_number - 1][:price]}円)ですね。"
   order_number
 end
 
@@ -30,5 +31,5 @@ order1 = take_order(DRINKS)
 puts 'フードメニューはいかがですか?'
 order2 = take_order(FOODS)
 
-total = FOODS[order1][:price] + DRINKS[order2][:price]
+total = FOODS[order2 - 1][:price] + DRINKS[order1 - 1][:price]
 puts "お会計は#{total}円になります。ありがとうございました！"


### PR DESCRIPTION
起きていた問題
- キーボードで入力した番号と表示されるメニューが一致しない
- お会計額が正しくない

原因
- キーボードで入力した番号が配列の要素指定に使われていたが、indexが0から始まることが考慮されておらず、一つずれて表示されていた
- totalに渡される金額が文字列だったため、金額の合計ではなく文字列の合体がされていた

対策
- 配列の引数に-1を追加した
  -  「表示されるメニューの入力番号は変更しない」制約があるため
- DRINKS, FOODS配列のpriceを文字列から数値にするため、シングルクォートを削除